### PR TITLE
FEM-2221 Add and handle assetReferenceType as a parameter in PhoenixMediaProvider

### DIFF
--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/api/phoenix/model/KalturaProgramAsset.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/api/phoenix/model/KalturaProgramAsset.java
@@ -1,0 +1,17 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
+package com.kaltura.playkit.providers.api.phoenix.model;
+
+public class KalturaProgramAsset extends KalturaMediaAsset {
+
+}

--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
@@ -304,8 +304,24 @@ public class PhoenixMediaProvider extends BEMediaProvider {
             }
 
             if (mediaAsset.assetReferenceType == null) {
-                mediaAsset.assetReferenceType = APIDefines.AssetReferenceType.Media;
+                if (mediaAsset.assetType == APIDefines.KalturaAssetType.Media) {
+                    mediaAsset.assetReferenceType = APIDefines.AssetReferenceType.Media;
+                } else {
+                    error = ErrorElement.BadRequestError.addMessage(": Missing required parameter [assetReferenceType]");
+                    return  error;
+                }
+            } else {
+                if ((mediaAsset.assetType == APIDefines.KalturaAssetType.Epg || mediaAsset.assetType == APIDefines.KalturaAssetType.Recording) &&
+                        mediaAsset.assetReferenceType == APIDefines.AssetReferenceType.Media) {
+                    error = ErrorElement.BadRequestError.addMessage(": Incompatible AssetReferenceType Media for Epg/Recording Asset");
+                    return error;
+                }
+                if (mediaAsset.assetType == APIDefines.KalturaAssetType.Media &&  mediaAsset.assetReferenceType != APIDefines.AssetReferenceType.Media) {
+                    error = ErrorElement.BadRequestError.addMessage(": Incompatible AssetReferenceType " +  mediaAsset.assetReferenceType + " for Media Asset");
+                    return error;
+                }
             }
+
             if (mediaAsset.contextType == null) {
                 mediaAsset.contextType = APIDefines.PlaybackContextType.Playback;
             }
@@ -579,7 +595,7 @@ public class PhoenixMediaProvider extends BEMediaProvider {
         }
         return metadata;
     }
-    
+
     private ErrorElement updateErrorElement(ResponseElement response, BaseResult loginResult, BaseResult playbackContextResult, BaseResult assetGetResult) {
         //error = ErrorElement.LoadError.message("failed to get multirequest responses on load request for asset "+mediaAsset.assetId);
         ErrorElement error;

--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
@@ -107,6 +107,8 @@ public class PhoenixMediaProvider extends BEMediaProvider {
 
         public APIDefines.KalturaAssetType assetType;
 
+        public APIDefines.AssetReferenceType assetReferenceType;
+
         public APIDefines.PlaybackContextType contextType;
 
         public List<String> formats;
@@ -182,6 +184,18 @@ public class PhoenixMediaProvider extends BEMediaProvider {
      */
     public PhoenixMediaProvider setAssetId(@NonNull String assetId) {
         this.mediaAsset.assetId = assetId;
+        return this;
+    }
+
+    /**
+     * ESSENTIAL in EPG!! defines the playing  AssetReferenceType especially in case of epg
+     * Defaults to - {@link APIDefines.KalturaAssetType#Media}
+     *
+     * @param assetReferenceType - can be one of the following types {@link APIDefines.AssetReferenceType}
+     * @return - instance of PhoenixMediaProvider
+     */
+    public PhoenixMediaProvider setAssetReferenceType(@NonNull APIDefines.AssetReferenceType assetReferenceType) {
+        this.mediaAsset.assetReferenceType = assetReferenceType;
         return this;
     }
 
@@ -288,6 +302,10 @@ public class PhoenixMediaProvider extends BEMediaProvider {
             if (mediaAsset.assetType == null) {
                 mediaAsset.assetType = APIDefines.KalturaAssetType.Media;
             }
+
+            if (mediaAsset.assetReferenceType == null) {
+                mediaAsset.assetReferenceType = APIDefines.AssetReferenceType.Media;
+            }
             if (mediaAsset.contextType == null) {
                 mediaAsset.contextType = APIDefines.PlaybackContextType.Playback;
             }
@@ -340,7 +358,7 @@ public class PhoenixMediaProvider extends BEMediaProvider {
         }
 
         private RequestBuilder getMediaAssetRequest(String baseUrl, String ks, MediaAsset mediaAsset) {
-            return AssetService.get(baseUrl, ks, mediaAsset.assetId, APIDefines.AssetReferenceType.Media);
+            return AssetService.get(baseUrl, ks, mediaAsset.assetId, mediaAsset.assetReferenceType);
         }
 
         private RequestBuilder getRemoteRequest(String baseUrl, String ks, String referrer, MediaAsset mediaAsset) {

--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
@@ -298,28 +298,19 @@ public class PhoenixMediaProvider extends BEMediaProvider {
 
         } else {
 
-            //set Defaults if not provided:
+            //set defaults if not provided:
             if (mediaAsset.assetType == null) {
                 mediaAsset.assetType = APIDefines.KalturaAssetType.Media;
             }
 
+            // If AssetType is Media, AssetReferenceType must be Media too
+            if (mediaAsset.assetType == APIDefines.KalturaAssetType.Media) {
+                mediaAsset.assetReferenceType = APIDefines.AssetReferenceType.Media;
+            }
+
             if (mediaAsset.assetReferenceType == null) {
-                if (mediaAsset.assetType == APIDefines.KalturaAssetType.Media) {
-                    mediaAsset.assetReferenceType = APIDefines.AssetReferenceType.Media;
-                } else {
-                    error = ErrorElement.BadRequestError.addMessage(": Missing required parameter [assetReferenceType]");
-                    return  error;
-                }
-            } else {
-                if ((mediaAsset.assetType == APIDefines.KalturaAssetType.Epg || mediaAsset.assetType == APIDefines.KalturaAssetType.Recording) &&
-                        mediaAsset.assetReferenceType == APIDefines.AssetReferenceType.Media) {
-                    error = ErrorElement.BadRequestError.addMessage(": Incompatible AssetReferenceType Media for Epg/Recording Asset");
-                    return error;
-                }
-                if (mediaAsset.assetType == APIDefines.KalturaAssetType.Media &&  mediaAsset.assetReferenceType != APIDefines.AssetReferenceType.Media) {
-                    error = ErrorElement.BadRequestError.addMessage(": Incompatible AssetReferenceType " +  mediaAsset.assetReferenceType + " for Media Asset");
-                    return error;
-                }
+                error = ErrorElement.BadRequestError.addMessage(": Missing required parameter [assetReferenceType]");
+                return  error;
             }
 
             if (mediaAsset.contextType == null) {


### PR DESCRIPTION
Add and handle assetReferenceType as a parameter in PhoenixMediaProvider

now in case app is playing EPG it should mention if it is internal or external EPG

mediaProvider = new PhoenixMediaProvider()
.setSessionProvider(ksSessionProvider)
.setAssetId(mediaId)
//.setReferrer()
.setProtocol(PhoenixMediaProvider.HttpProtocol.Https)
.setContextType(APIDefines.PlaybackContextType.Catchup)
.setAssetType(APIDefines.KalturaAssetType.Epg)
.setFileIds(fileIds)
.setAssetReferenceType(APIDefines.AssetReferenceType.InternalEpg);

mediaProvider.load(completion);
}

public enum AssetReferenceType {
Media("media"),
InternalEpg("epg_internal"),
ExternalEpg("epg_external");

public String value;

AssetReferenceType(String value){
this.value = value;
}
}