### PR TITLE
FEM-2575 redirectFromEntryId logic in OVPMediaProvider is broken

### DIFF
--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/api/ovp/services/MetaDataService.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/api/ovp/services/MetaDataService.java
@@ -23,9 +23,9 @@ public class MetaDataService extends OvpService {
 
     public static OvpRequestBuilder list(String baseUrl, String ks, String entryId) {
         JsonObject filter = new JsonObject();
-        filter.addProperty("objectType","KalturaMetadataFilter");
-        filter.addProperty("objectIdEqual",entryId);
-        filter.addProperty("metadataObjectTypeEqual","1");
+        filter.addProperty("objectType", "KalturaMetadataFilter");
+        filter.addProperty("objectIdEqual", entryId);
+        filter.addProperty("metadataObjectTypeEqual", "1");
 
         JsonObject params = new JsonObject();
         params.add("filter", filter);

--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/ovp/KalturaOvpMediaProvider.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/ovp/KalturaOvpMediaProvider.java
@@ -212,15 +212,18 @@ public class KalturaOvpMediaProvider extends BEMediaProvider {
             MultiRequestBuilder multiRequestBuilder = (MultiRequestBuilder) OvpService.getMultirequest(baseUrl, ks, partnerId)
                     .tag("entry-info-multireq");
 
-            if (TextUtils.isEmpty(ks)) {
-                multiRequestBuilder.add(OvpSessionService.anonymousSession(baseUrl, partnerId));
+            String baseEntryServiceEntryId = "{1:result:objects:0:id}";
 
+            boolean isAnonymusKS = TextUtils.isEmpty(ks);
+            if (isAnonymusKS) {
+                multiRequestBuilder.add(OvpSessionService.anonymousSession(baseUrl, partnerId));
                 ks = "{1:result:ks}";
+                baseEntryServiceEntryId = "{2:result:objects:0:id}";
             }
 
             return multiRequestBuilder.add(BaseEntryService.list(baseUrl, ks, entryId),
-                    BaseEntryService.getPlaybackContext(baseUrl, ks, entryId, referrer),
-                    MetaDataService.list(baseUrl, ks, entryId));
+                    BaseEntryService.getPlaybackContext(baseUrl, ks, baseEntryServiceEntryId, referrer),
+                    MetaDataService.list(baseUrl, ks, baseEntryServiceEntryId));
         }
 
         /**


### PR DESCRIPTION
incase of live media that was moved to be ovp media we have to use the entryId (id) that is returned in the baseEntryService instead of the given entryId when doing getPlaybackContext and metadata requests
on anonymous ks the base entry index in multi request is 2
in none anonymous ks base entry index multi request is 1