### PR TITLE
FEM-2668 update phoenix/ovp providers error handling

### DIFF
--- a/mediaproviders/build.gradle
+++ b/mediaproviders/build.gradle
@@ -36,7 +36,7 @@ tasks.withType(Javadoc) {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    api 'com.kaltura.netkit:netkit-core:1.3.1'
+    api 'com.kaltura.netkit:netkit-core:1.3.2'
     //api project(":netkit")
 
     implementation 'com.kaltura:playkit-android:dev-SNAPSHOT'

--- a/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
@@ -45,6 +45,7 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
     private static final PKLog log = PKLog.get("PhoenixAnalyticsPlugin");
     private static final double MEDIA_ENDED_THRESHOLD = 0.98;
     public static final String CONCURRENCY_ERROR_CODE = "4001";
+    public static final String CONCURRENCY_ERROR_STRING = "ConcurrencyLimitation";
 
     // Fields shared with TVPAPIAnalyticsPlugin
     int mediaHitInterval;
@@ -432,7 +433,7 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
                             String errorCode = error.getString("code");
                             String errorMessage = error.getString("message");
 
-                            if (TextUtils.equals(errorCode, CONCURRENCY_ERROR_CODE)) {
+                            if (TextUtils.equals(errorCode, CONCURRENCY_ERROR_CODE) || TextUtils.equals(errorCode, CONCURRENCY_ERROR_STRING) ) {
                                 sendConcurrencyErrorEvent(errorMessage);
                             } else {
                                 messageBus.post(new PhoenixAnalyticsEvent.BookmarkErrorEvent(Integer.parseInt(errorCode), errorMessage));

--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/api/phoenix/PhoenixErrorHelper.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/api/phoenix/PhoenixErrorHelper.java
@@ -97,10 +97,12 @@ public class PhoenixErrorHelper {
                 return new RestrictionError("content is not entitled", RestrictionError.Restriction.NotEntitled);
 
             case "ConcurrencyLimitation":
-            case "MediaConcurrencyLimitation":
-            case "4000":
             case "4001":
                 return new RestrictionError("restricted due to concurrency limitation", RestrictionError.Restriction.ConcurrencyLimitation);
+
+            case "MediaConcurrencyLimitation":
+            case "4000":
+                return new RestrictionError("restricted due to concurrency limitation", RestrictionError.Restriction.MediaConcurrencyLimitation);
 
             case "2001":
                 return new RestrictionError("restricted due to suspended account", RestrictionError.Restriction.Suspended);

--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
@@ -353,7 +353,7 @@ public class PhoenixMediaProvider extends BEMediaProvider {
 
             this.mediaAsset = mediaAsset;
 
-            PKLog.v(TAG, loadId + ": construct new Loader");
+            log.v(loadId + ": construct new Loader");
         }
 
         @Override
@@ -424,7 +424,7 @@ public class PhoenixMediaProvider extends BEMediaProvider {
                     .completion(new OnRequestCompletion() {
                         @Override
                         public void onComplete(ResponseElement response) {
-                            PKLog.v(TAG, loadId + ": got response to [" + loadReq + "]");
+                            log.v(loadId + ": got response to [" + loadReq + "]");
                             loadReq = null;
 
                             try {
@@ -438,16 +438,16 @@ public class PhoenixMediaProvider extends BEMediaProvider {
 
             synchronized (syncObject) {
                 loadReq = requestQueue.queue(requestBuilder.build());
-                PKLog.d(TAG, loadId + ": request queued for execution [" + loadReq + "]");
+                log.d(loadId + ": request queued for execution [" + loadReq + "]");
             }
 
             if (!isCanceled()) {
-                PKLog.v(TAG, loadId + " set waitCompletion");
+                log.v(loadId + " set waitCompletion");
                 waitCompletion();
             } else {
-                PKLog.v(TAG, loadId + " was canceled.");
+                log.v(loadId + " was canceled.");
             }
-            PKLog.v(TAG, loadId + ": requestRemote wait released");
+            log.v(loadId + ": requestRemote wait released");
         }
 
         private String getApiBaseUrl() {
@@ -466,7 +466,7 @@ public class PhoenixMediaProvider extends BEMediaProvider {
             PKMediaEntry mediaEntry = null;
 
             if (isCanceled()) {
-                PKLog.v(TAG, loadId + ": i am canceled, exit response parsing ");
+                log.v(loadId + ": i am canceled, exit response parsing ");
                 return;
             }
 
@@ -511,7 +511,7 @@ public class PhoenixMediaProvider extends BEMediaProvider {
 
                     //*************************
 
-                    PKLog.d(TAG, loadId + ": parsing response  [" + Loader.this.toString() + "]");
+                    log.d(loadId + ": parsing response  [" + Loader.this.toString() + "]");
                     /* 3. <T> T PhoenixParser.parse(String response): parse json string to an object of dynamically parsed type.
                        type defined by the value of "objectType" property provided in the response objects, if type wasn't found or in
                        case of error object in the response, will be parsed to BaseResult object (error if occurred will be accessible from this object)*/
@@ -578,13 +578,13 @@ public class PhoenixMediaProvider extends BEMediaProvider {
                 error = response != null && response.getError() != null ? response.getError() : ErrorElement.LoadError;
             }
 
-            PKLog.i(TAG, loadId + ": load operation " + (isCanceled() ? "canceled" : "finished with " + (error == null ? "success" : "failure")));
+            log.i(loadId + ": load operation " + (isCanceled() ? "canceled" : "finished with " + (error == null ? "success" : "failure")));
 
             if (!isCanceled() && completion != null) {
                 completion.onComplete(Accessories.buildResult(mediaEntry, error));
             }
 
-            PKLog.w(TAG, loadId + " media load finished, callback passed...notifyCompletion");
+            log.w(loadId + " media load finished, callback passed...notifyCompletion");
             notifyCompletion();
 
         }

--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/ott/PhoenixMediaProvider.java
@@ -615,6 +615,7 @@ public class PhoenixMediaProvider extends BEMediaProvider {
                     JSONObject apiException = new JSONObject(response.getResponse());
                     if (apiException != null) {
                         if (apiException.has(RESULT)) {
+                            String ottError = "OTTError";
                             if (apiException.get(RESULT) instanceof JSONObject) {
 
                                 JSONObject result = (JSONObject) apiException.get(RESULT);
@@ -622,7 +623,7 @@ public class PhoenixMediaProvider extends BEMediaProvider {
                                     JSONObject error = (JSONObject) result.get(ERROR);
                                     Map<String, String> errorMap = getAPIExceptionData(error);
                                     if (errorMap != null) {
-                                        return new ErrorElement(errorMap.get(MESSAGE), errorMap.get(CODE), errorMap.get(OBJECT_TYPE)).setName("OTTError");
+                                        return new ErrorElement(errorMap.get(MESSAGE), errorMap.get(CODE), errorMap.get(OBJECT_TYPE)).setName(ottError);
                                     }
                                 }
                             } else if (apiException.get(RESULT) instanceof JSONArray) {
@@ -634,7 +635,7 @@ public class PhoenixMediaProvider extends BEMediaProvider {
                                         JSONObject resultIndexJsonObjectError = (JSONObject) error.get(ERROR);
                                         Map<String, String> errorMap = getAPIExceptionData(resultIndexJsonObjectError);
                                         if (errorMap != null) {
-                                            return new ErrorElement(errorMap.get(MESSAGE), errorMap.get(CODE), errorMap.get(OBJECT_TYPE)).setName("OTTError");
+                                            return new ErrorElement(errorMap.get(MESSAGE), errorMap.get(CODE), errorMap.get(OBJECT_TYPE)).setName(ottError);
                                         }
                                     }
                                 }

--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/ovp/KalturaOvpMediaProvider.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/ovp/KalturaOvpMediaProvider.java
@@ -70,8 +70,7 @@ import static com.kaltura.netkit.utils.ErrorElement.GeneralError;
 
 public class KalturaOvpMediaProvider extends BEMediaProvider {
 
-    private static final String TAG = KalturaOvpMediaProvider.class.getSimpleName();
-    private static final PKLog log = PKLog.get(TAG);
+    private static final PKLog log = PKLog.get("KalturaOvpMediaProvider");
 
     public static final String KALTURA_API_EXCEPTION = "KalturaAPIException";
     public static final String OBJECT_TYPE = "objectType";
@@ -89,7 +88,7 @@ public class KalturaOvpMediaProvider extends BEMediaProvider {
     private Map<String, Object> flavorsFilter;
 
     public KalturaOvpMediaProvider() {
-        super(KalturaOvpMediaProvider.TAG);
+        super(log.tag);
     }
 
     public KalturaOvpMediaProvider(final String baseUrl, final int partnerId, final String ks) {
@@ -194,7 +193,7 @@ public class KalturaOvpMediaProvider extends BEMediaProvider {
         private String referrer;
 
         Loader(RequestQueue requestsExecutor, SessionProvider sessionProvider, String entryId, String uiConfId, String referrer, OnMediaLoadCompletion completion) {
-            super(KalturaOvpMediaProvider.TAG + "#Loader", requestsExecutor, sessionProvider, completion);
+            super(log.tag + "#Loader", requestsExecutor, sessionProvider, completion);
 
             this.entryId = entryId;
             this.uiConfId = uiConfId;

--- a/mediaproviders/src/main/java/com/kaltura/playkit/providers/ovp/KalturaOvpMediaProvider.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/providers/ovp/KalturaOvpMediaProvider.java
@@ -385,13 +385,14 @@ public class KalturaOvpMediaProvider extends BEMediaProvider {
         if (response != null) {
             String responseStr = response.getResponse();
             try {
+                String ovpError = "OVPError";
                 if (responseStr != null && responseStr.startsWith("{") && responseStr.endsWith("}")) {
 
                     JSONObject error = new JSONObject(response.getResponse());
                     if (error != null) {
                         Map<String, String> errorMap = getAPIExceptionData(error);
                         if (errorMap != null) {
-                            return new ErrorElement(errorMap.get(MESSAGE), errorMap.get(CODE), errorMap.get(OBJECT_TYPE)).setName("OVPError");
+                            return new ErrorElement(errorMap.get(MESSAGE), errorMap.get(CODE), errorMap.get(OBJECT_TYPE)).setName(ovpError);
                         }
                     }
 
@@ -401,7 +402,7 @@ public class KalturaOvpMediaProvider extends BEMediaProvider {
                         JSONObject error = (JSONObject) result.get(idx);
                         Map<String, String> errorMap = getAPIExceptionData(error);
                         if (errorMap != null && KALTURA_API_EXCEPTION.equals(errorMap.get(OBJECT_TYPE))) {
-                            return new ErrorElement(errorMap.get(MESSAGE), errorMap.get(CODE), errorMap.get(OBJECT_TYPE)).setName("OVPError");
+                            return new ErrorElement(errorMap.get(MESSAGE), errorMap.get(CODE), errorMap.get(OBJECT_TYPE)).setName(ovpError);
                         }
                     }
                 }


### PR DESCRIPTION
add API so we can return Error Element same as retrieved from Response without any changes

        private boolean isAPIExceptionResponse(ResponseElement response) {
            return response.isSuccess() && response.getError() == null && response.getResponse() != null && response.getResponse().contains("KalturaAPIException");
        }

        private boolean isErrorResponse(ResponseElement response) {
            return !response.isSuccess() && response.getError() != null;
        }