### PR TITLE
FEC-12083 Fixed: `Stop` event was sending incorrect data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ PhoenixAnalyticsConfig phoenixAnalyticsConfig = new PhoenixAnalyticsConfig(INT_P
 config.setPluginConfig(PhoenixAnalyticsPlugin.factory.getName(), phoenixAnalyticsConfig);
 ``` 
 
-Here `timerInterval` field is the frequency of "Hit" or "Ping" going to the server for tracking.
+Here `timerInterval` field is the frequency of "Hit" or "Ping" going to the server for tracking. Value should be passed in **'Seconds'**.
 
 > ##### Listen to the PhoenixAnalyticsEvents
 

--- a/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsConfig.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsConfig.java
@@ -33,7 +33,7 @@ public class PhoenixAnalyticsConfig {
     private int partnerId;
     private String baseUrl;
     private String ks;
-    private int timerInterval;
+    private int timerInterval; // In Seconds
     private boolean disableMediaHit;
     private boolean disableMediaMark;
     private String epgId;

--- a/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
@@ -263,6 +263,7 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
 
         messageBus.addListener(this, PlayerEvent.seeked, event -> {
             printReceivedEvent(event);
+            updateLastKnownPlayerPosition();
             isMediaFinished = false;
         });
 
@@ -279,7 +280,6 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
         messageBus.addListener(this, AdEvent.contentResumeRequested, event -> {
             log.d("Ad Event = " + event.eventType().name() + ", lastKnownPlayerPosition = " + lastKnownPlayerPosition);
             isAdPlaying = false;
-
         });
     }
 
@@ -348,12 +348,7 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
     @Override
     protected void onApplicationPaused() {
         log.d("PhoenixAnalyticsPlugin onApplicationPaused");
-        if (player != null) {
-            long playerPosOnPause = player.getCurrentPosition();
-            if (playerPosOnPause > 0 && !isAdPlaying) {
-                lastKnownPlayerPosition = playerPosOnPause / Consts.MILLISECONDS_MULTIPLIER;
-            }
-        }
+        updateLastKnownPlayerPosition();
         cancelTimer();
     }
 
@@ -392,6 +387,19 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
             return mediaConfig.getMediaEntry();
         }
         return null;
+    }
+
+    /**
+     * Update `lastKnownPlayerPosition` by taking
+     * the player current position
+     */
+    private void updateLastKnownPlayerPosition() {
+        if (player != null) {
+            long currentPosition = player.getCurrentPosition();
+            if (currentPosition > 0 && !isAdPlaying) {
+                lastKnownPlayerPosition = currentPosition / Consts.MILLISECONDS_MULTIPLIER;
+            }
+        }
     }
 
     /**

--- a/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
@@ -163,7 +163,9 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
         messageBus.addListener(this, PlayerEvent.ended, event -> {
             printReceivedEvent(event);
             resetTimer();
-            sendAnalyticsEvent(PhoenixActionType.FINISH);
+            if (!isMediaFinished) {
+                sendAnalyticsEvent(PhoenixActionType.FINISH);
+            }
             playEventWasFired = false;
             isMediaFinished = true;
             isFirstPlay = true;
@@ -328,9 +330,6 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
         isFirstPlay = true;
         playEventWasFired = false;
         isMediaFinished = false;
-        currentMediaId = "UnKnown";
-        currentAssetType = APIDefines.KalturaAssetType.Media.value;
-        lastKnownPlayerPosition = 0;
         lastKnownPlayerDuration = 0;
     }
 
@@ -416,7 +415,9 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
             @Override
             public void run() {
                 sendAnalyticsEvent(PhoenixActionType.HIT);
-                if (lastKnownPlayerDuration > 0 && ((float) lastKnownPlayerPosition / lastKnownPlayerDuration > MEDIA_ENDED_THRESHOLD)) {
+                if (lastKnownPlayerDuration > 0 &&
+                        ((float) lastKnownPlayerPosition / lastKnownPlayerDuration > MEDIA_ENDED_THRESHOLD) &&
+                        !isMediaFinished) {
                     sendAnalyticsEvent(PhoenixActionType.FINISH);
                     playEventWasFired = false;
                     isMediaFinished = true;


### PR DESCRIPTION
- `Stop` event was sending 0 is position, wrong mediaId and assetType
- `Finish` event was being sent twice. [Scenario: If media if of 120 seconds and frequency timer is also of 30 seconds then when the media is about to finish; then `Finish` was being sent twice. One from the timer and one from the `PlayerEvent.ended` 