### PR TITLE
FEC-12787 - ConcurrencyErrorEvent is not fired

### DIFF
--- a/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
@@ -253,6 +253,7 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
             if (isFirstPlay) {
                 playEventWasFired = true;
                 sendAnalyticsEvent(PhoenixActionType.FIRST_PLAY);
+                sendAnalyticsEvent(PhoenixActionType.PLAY);
                 sendAnalyticsEvent(PhoenixActionType.HIT);
             }
             if (!intervalOn) {


### PR DESCRIPTION
adding PLAY event after FIRST_PLAY - this will help BE to fire ConcurrencyErrorEvent


[FEC-12787](https://kaltura.atlassian.net/browse/FEC-12787)