### PR TITLE
fix: FEC-12835 Add `forceConcurencyOnUnpaidContent` in PhoenixAnalytics Config

### DIFF
--- a/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsConfig.java
+++ b/mediaproviders/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsConfig.java
@@ -38,6 +38,7 @@ public class PhoenixAnalyticsConfig {
     private boolean disableMediaMark;
     private String epgId;
     private boolean experimentalLiveMediaHit;
+    private boolean forceConcurrencyOnUnpaidContent;
 
     public PhoenixAnalyticsConfig() {}
 
@@ -126,6 +127,11 @@ public class PhoenixAnalyticsConfig {
         return this;
     }
 
+    public PhoenixAnalyticsConfig setForceConcurrencyOnUnpaidContent(boolean forceConcurrencyOnUnpaidContent) {
+        this.forceConcurrencyOnUnpaidContent = forceConcurrencyOnUnpaidContent;
+        return this;
+    }
+
     public int getPartnerId() {
         return partnerId;
     }
@@ -156,6 +162,10 @@ public class PhoenixAnalyticsConfig {
 
     public boolean getExperimentalLiveMediaHit() {
         return experimentalLiveMediaHit;
+    }
+
+    public boolean isForceConcurrencyOnUnpaidContent() {
+        return forceConcurrencyOnUnpaidContent;
     }
 
     public JsonObject toJson() {


### PR DESCRIPTION
- Add config in the documentation.
- There are cases where customers may have concurrency limitation module while they do not have paid content
  so unless there is special configuration on BE  there is no possibility to force the concurrency by phoenixAnalyitics plugin by setting this flag the plugin will force that rule